### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.3'
+    classpath('com.android.tools.build:gradle:4.2.2')
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }


### PR DESCRIPTION
Update Gradle version to 4.2.2 to prevent build error due to unavailable Google recourses.